### PR TITLE
Refactor sensors to zones: separate physical devices from logical locations

### DIFF
--- a/heim/db/migrations/0017_add_zones.sql
+++ b/heim/db/migrations/0017_add_zones.sql
@@ -1,0 +1,63 @@
+-- Add zone concept to separate physical sensors from logical measurement locations
+--
+-- Zones represent logical locations we want to track over time (e.g., "Living Room").
+-- Sensors are physical devices that can be assigned to zones for specific time periods.
+-- This allows moving sensors between zones and replacing sensors while maintaining
+-- continuous historical data for a zone.
+
+-- Create zone table (logical measurement location)
+create table zone (
+    id integer primary key generated always as identity,
+    location_id integer not null references location(id),
+    name text not null,
+    is_outdoor boolean not null default false,
+    color text,
+    unique (location_id, name)
+);
+
+-- Create sensor-zone assignment table with time ranges
+-- Uses GiST exclusion constraint to prevent overlapping assignments for the same sensor
+create table sensor_zone_assignment (
+    id integer primary key generated always as identity,
+    zone_id integer not null references zone(id),
+    sensor_id integer not null references sensor(id),
+    active_range tstzrange not null,
+    -- Prevent a sensor from being assigned to multiple zones at the same time
+    exclude using gist (sensor_id with =, active_range with &&)
+);
+
+create index sensor_zone_assignment_zone_id_idx on sensor_zone_assignment(zone_id);
+create index sensor_zone_assignment_sensor_id_idx on sensor_zone_assignment(sensor_id);
+create index sensor_zone_assignment_active_range_idx on sensor_zone_assignment using gist(active_range);
+
+-- Migrate existing sensors to zones:
+-- 1. Create a zone for each existing sensor with the same name, location, is_outdoor, and color
+-- 2. Create an assignment from the sensor to the zone, starting from the sensor's first measurement
+
+-- Step 1: Create zones from existing sensors
+insert into zone (location_id, name, is_outdoor, color)
+select location_id, coalesce(name, 'Sensor ' || id), coalesce(is_outdoor, false), color
+from sensor;
+
+-- Step 2: Create assignments from sensors to their corresponding zones
+-- The assignment starts from the sensor's first measurement (or now if no measurements)
+-- and is open-ended (null upper bound means still active)
+insert into sensor_zone_assignment (zone_id, sensor_id, active_range)
+select
+    z.id as zone_id,
+    s.id as sensor_id,
+    tstzrange(
+        coalesce(
+            (select min(measured_at) from sensor_measurement where sensor_id = s.id),
+            now()
+        ),
+        null,
+        '[)'
+    ) as active_range
+from sensor s
+join zone z on z.location_id = s.location_id
+    and z.name = coalesce(s.name, 'Sensor ' || s.id);
+
+-- Note: We keep sensor.location_id, sensor.is_outdoor, and sensor.color for now
+-- to allow gradual migration of code. These columns can be dropped in a future
+-- migration once all code uses zones instead.

--- a/heim/frontend/templates/index.html
+++ b/heim/frontend/templates/index.html
@@ -51,7 +51,7 @@
         </div>
       </div>
       {% endif %}
-      {% if sensor_data %}
+      {% if zone_data %}
       <div class="col-12 mt-4">
         <div class="card">
           <div class="card-body">
@@ -519,26 +519,26 @@
       });
     }
 
-    const sensorData = {{ sensor_data | tojson }};
+    const zoneData = {{ zone_data | tojson }};
     const now = new Date();
     const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
 
-    // Generate a stable color from sensor ID using a simple hash
-    function getColorForSensor(sensorId) {
+    // Generate a stable color from zone ID using a simple hash
+    function getColorForZone(zoneId) {
       // Use golden ratio to spread colors evenly
-      const hue = (sensorId * 137.508) % 360;
+      const hue = (zoneId * 137.508) % 360;
       return `hsl(${hue}, 70%, 50%)`;
     }
 
-    if (sensorData.length > 0) {
+    if (zoneData.length > 0) {
       const ctx = document.getElementById('indoor-chart');
-      const datasets = sensorData.map(sensor => ({
-        label: sensor.name,
-        data: sensor.labels.map((l, i) => ({
+      const datasets = zoneData.map(zone => ({
+        label: zone.name,
+        data: zone.labels.map((l, i) => ({
           x: new Date(l),
-          y: sensor.values[i]
+          y: zone.values[i]
         })),
-        borderColor: sensor.color || getColorForSensor(sensor.id),
+        borderColor: zone.color || getColorForZone(zone.id),
         tension: 0.1,
         fill: false,
         pointRadius: 0,

--- a/heim/frontend/templates/settings/layout.html
+++ b/heim/frontend/templates/settings/layout.html
@@ -51,6 +51,11 @@
               </a>
             </li>
             <li class="nav-item">
+              <a class="nav-link {% if active_tab == 'zones' %}active{% endif %}" href="/settings/zones/">
+                Zones
+              </a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link {% if active_tab == 'sensors' %}active{% endif %}" href="/settings/sensors/">
                 Sensors
               </a>

--- a/heim/frontend/templates/settings/sensor_detail.html
+++ b/heim/frontend/templates/settings/sensor_detail.html
@@ -17,42 +17,29 @@
       <div class="mb-3">
         <label for="name" class="form-label">Name</label>
         <input type="text" class="form-control" id="name" name="name" required value="{{ sensor.name or '' }}">
-        <div class="form-text">A descriptive name for this sensor.</div>
+        <div class="form-text">A descriptive name for this sensor (the physical device).</div>
       </div>
 
       <div class="mb-3">
         <label class="form-label">Location</label>
         <input type="text" class="form-control" value="{{ sensor.location_name }}" disabled>
-        <div class="form-text">Location cannot be changed after sensor creation.</div>
       </div>
 
-      <div class="mb-3 form-check">
-        <input type="checkbox" class="form-check-input" id="is_outdoor" name="is_outdoor" value="true" {% if sensor.is_outdoor %}checked{% endif %}>
-        <label class="form-check-label" for="is_outdoor">Outdoor sensor</label>
-        <div class="form-text">Mark this sensor as outdoor to use it for outdoor temperature readings.</div>
-      </div>
-
+      {% if current_zone %}
       <div class="mb-3">
-        <label for="color" class="form-label">Chart color</label>
-        <div class="input-group" style="max-width: 200px;">
-          <input type="color" class="form-control form-control-color" id="color-picker" value="{{ sensor.color or '#808080' }}" title="Choose color">
-          <input type="text" class="form-control" id="color" name="color" value="{{ sensor.color or '' }}" placeholder="#rrggbb">
+        <label class="form-label">Current Zone</label>
+        <div>
+          <a href="/settings/zones/{{ current_zone.id }}/" class="btn btn-outline-primary btn-sm">
+            {{ current_zone.name }}
+          </a>
         </div>
-        <div class="form-text">Color to use in charts. Leave empty for auto-generated color.</div>
+        <div class="form-text">This sensor is assigned to a zone. Manage zone assignments in <a href="/settings/zones/">zone settings</a>.</div>
       </div>
-      <script>
-        // Sync color picker with text input
-        const colorPicker = document.getElementById('color-picker');
-        const colorInput = document.getElementById('color');
-        colorPicker.addEventListener('input', (e) => {
-          colorInput.value = e.target.value;
-        });
-        colorInput.addEventListener('input', (e) => {
-          if (/^#[0-9A-Fa-f]{6}$/.test(e.target.value)) {
-            colorPicker.value = e.target.value;
-          }
-        });
-      </script>
+      {% else %}
+      <div class="alert alert-warning">
+        This sensor is not assigned to any zone. Assign it in <a href="/settings/zones/">zone settings</a> to see its data in charts.
+      </div>
+      {% endif %}
 
       <div class="d-flex gap-2">
         <button type="submit" class="btn btn-primary">Save Changes</button>

--- a/heim/frontend/templates/settings/sensors.html
+++ b/heim/frontend/templates/settings/sensors.html
@@ -5,31 +5,22 @@
   <h2>Sensors</h2>
 </div>
 
-<p class="text-body-secondary">Manage your sensors. Edit names and configure which sensors are outdoor sensors.</p>
+<p class="text-body-secondary">Manage your physical sensor devices. Assign sensors to zones in <a href="/settings/zones/">zone settings</a> to see their data in charts.</p>
 
 {% if sensors %}
 <div class="table-responsive">
   <table class="table table-hover">
     <thead>
       <tr>
-        <th>Color</th>
         <th>Name</th>
         <th>Location</th>
         <th>Source</th>
-        <th>Outdoor</th>
         <th>Actions</th>
       </tr>
     </thead>
     <tbody>
-      {% for sensor_id, name, location_name, is_outdoor, source, color in sensors %}
+      {% for sensor_id, name, location_name, source in sensors %}
       <tr>
-        <td>
-          {% if color %}
-            <span style="display: inline-block; width: 20px; height: 20px; background-color: {{ color }}; border-radius: 3px; vertical-align: middle;"></span>
-          {% else %}
-            <span class="text-body-secondary">—</span>
-          {% endif %}
-        </td>
         <td>
           <a href="/settings/sensors/{{ sensor_id }}/">{{ name or '(unnamed)' }}</a>
         </td>
@@ -41,11 +32,6 @@
             <span class="badge bg-success">Aqara</span>
           {% else %}
             <span class="badge bg-secondary">Manual</span>
-          {% endif %}
-        </td>
-        <td>
-          {% if is_outdoor %}
-            <span class="badge bg-primary">Outdoor</span>
           {% endif %}
         </td>
         <td>

--- a/heim/frontend/templates/settings/zone_detail.html
+++ b/heim/frontend/templates/settings/zone_detail.html
@@ -1,0 +1,137 @@
+{% extends "settings/layout.html" %}
+
+{% block content %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="/settings/zones/">Zones</a></li>
+    <li class="breadcrumb-item active" aria-current="page">{{ zone.name }}</li>
+  </ol>
+</nav>
+
+<h2>Edit Zone</h2>
+<p class="text-body-secondary">Update zone details and manage sensor assignments.</p>
+
+<div class="row">
+  <div class="col-md-6">
+    <form method="post" action="/settings/zones/{{ zone.id }}/">
+      <div class="mb-3">
+        <label for="name" class="form-label">Name</label>
+        <input type="text" class="form-control" id="name" name="name" required value="{{ zone.name }}">
+        <div class="form-text">A descriptive name for this zone (e.g., "Living Room", "Garden").</div>
+      </div>
+
+      <div class="mb-3">
+        <label class="form-label">Location</label>
+        <input type="text" class="form-control" value="{{ zone.location_name }}" disabled>
+        <div class="form-text">Location cannot be changed after zone creation.</div>
+      </div>
+
+      <div class="mb-3 form-check">
+        <input type="checkbox" class="form-check-input" id="is_outdoor" name="is_outdoor" value="true" {% if zone.is_outdoor %}checked{% endif %}>
+        <label class="form-check-label" for="is_outdoor">Outdoor zone</label>
+        <div class="form-text">Mark this zone as outdoor to include it in the outdoor temperature chart.</div>
+      </div>
+
+      <div class="mb-3">
+        <label for="color" class="form-label">Chart color</label>
+        <div class="input-group" style="max-width: 200px;">
+          <input type="color" class="form-control form-control-color" id="color-picker" value="{{ zone.color or '#808080' }}" title="Choose color">
+          <input type="text" class="form-control" id="color" name="color" value="{{ zone.color or '' }}" placeholder="#rrggbb">
+        </div>
+        <div class="form-text">Color to use in charts. Leave empty for auto-generated color.</div>
+      </div>
+      <script>
+        // Sync color picker with text input
+        const colorPicker = document.getElementById('color-picker');
+        const colorInput = document.getElementById('color');
+        colorPicker.addEventListener('input', (e) => {
+          colorInput.value = e.target.value;
+        });
+        colorInput.addEventListener('input', (e) => {
+          if (/^#[0-9A-Fa-f]{6}$/.test(e.target.value)) {
+            colorPicker.value = e.target.value;
+          }
+        });
+      </script>
+
+      <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Save Changes</button>
+        <a href="/settings/zones/" class="btn btn-outline-secondary">Cancel</a>
+      </div>
+    </form>
+  </div>
+</div>
+
+<hr class="my-4">
+
+<h4>Sensor Assignment</h4>
+<p class="text-body-secondary">Assign a sensor to this zone to start collecting measurements.</p>
+
+<div class="row">
+  <div class="col-md-6">
+    {% if current_assignment %}
+    <div class="alert alert-success">
+      <strong>Currently assigned:</strong> {{ current_assignment.sensor_name or 'Sensor ' ~ current_assignment.sensor_id }}
+      <form method="post" action="/settings/zones/{{ zone.id }}/unassign/" class="d-inline">
+        <button type="submit" class="btn btn-sm btn-outline-danger ms-2">Unassign</button>
+      </form>
+    </div>
+    {% else %}
+    <div class="alert alert-warning">
+      No sensor currently assigned to this zone.
+    </div>
+    {% endif %}
+
+    <form method="post" action="/settings/zones/{{ zone.id }}/assign/">
+      <div class="mb-3">
+        <label for="sensor_id" class="form-label">Assign sensor</label>
+        <select class="form-select" id="sensor_id" name="sensor_id" required>
+          <option value="">Select a sensor...</option>
+          {% for sensor in available_sensors %}
+          <option value="{{ sensor.id }}">
+            {{ sensor.name or 'Sensor ' ~ sensor.id }}
+            {% if sensor.current_zone %}(currently in {{ sensor.current_zone }}){% endif %}
+          </option>
+          {% endfor %}
+        </select>
+        <div class="form-text">Select a sensor to assign to this zone. If the sensor is already assigned elsewhere, it will be moved here.</div>
+      </div>
+      <button type="submit" class="btn btn-outline-primary">Assign Sensor</button>
+    </form>
+  </div>
+</div>
+
+{% if assignments %}
+<hr class="my-4">
+
+<h4>Assignment History</h4>
+<p class="text-body-secondary">Previous sensors that have been assigned to this zone.</p>
+
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th>Sensor</th>
+        <th>From</th>
+        <th>Until</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for assignment_id, sensor_id, sensor_name, start_time, end_time in assignments %}
+      <tr>
+        <td>{{ sensor_name or 'Sensor ' ~ sensor_id }}</td>
+        <td>{{ start_time.strftime('%Y-%m-%d %H:%M') }}</td>
+        <td>
+          {% if end_time %}
+            {{ end_time.strftime('%Y-%m-%d %H:%M') }}
+          {% else %}
+            <span class="badge bg-success">Active</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+{% endblock %}

--- a/heim/frontend/templates/settings/zone_form.html
+++ b/heim/frontend/templates/settings/zone_form.html
@@ -1,0 +1,69 @@
+{% extends "settings/layout.html" %}
+
+{% block content %}
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item"><a href="/settings/zones/">Zones</a></li>
+    <li class="breadcrumb-item active" aria-current="page">New Zone</li>
+  </ol>
+</nav>
+
+<h2>Add Zone</h2>
+<p class="text-body-secondary">Create a new zone to track measurements at a specific location.</p>
+
+<div class="row">
+  <div class="col-md-6">
+    <form method="post" action="/settings/zones/new/">
+      <div class="mb-3">
+        <label for="name" class="form-label">Name</label>
+        <input type="text" class="form-control" id="name" name="name" required placeholder="e.g., Living Room">
+        <div class="form-text">A descriptive name for this zone.</div>
+      </div>
+
+      <div class="mb-3">
+        <label for="location_id" class="form-label">Location</label>
+        <select class="form-select" id="location_id" name="location_id" required>
+          <option value="">Select a location...</option>
+          {% for location in locations %}
+          <option value="{{ location.id }}">{{ location.name }}</option>
+          {% endfor %}
+        </select>
+        <div class="form-text">The location this zone belongs to.</div>
+      </div>
+
+      <div class="mb-3 form-check">
+        <input type="checkbox" class="form-check-input" id="is_outdoor" name="is_outdoor" value="true">
+        <label class="form-check-label" for="is_outdoor">Outdoor zone</label>
+        <div class="form-text">Mark this zone as outdoor to include it in the outdoor temperature chart.</div>
+      </div>
+
+      <div class="mb-3">
+        <label for="color" class="form-label">Chart color (optional)</label>
+        <div class="input-group" style="max-width: 200px;">
+          <input type="color" class="form-control form-control-color" id="color-picker" value="#808080" title="Choose color">
+          <input type="text" class="form-control" id="color" name="color" value="" placeholder="#rrggbb">
+        </div>
+        <div class="form-text">Color to use in charts. Leave empty for auto-generated color.</div>
+      </div>
+      <script>
+        // Sync color picker with text input
+        const colorPicker = document.getElementById('color-picker');
+        const colorInput = document.getElementById('color');
+        colorPicker.addEventListener('input', (e) => {
+          colorInput.value = e.target.value;
+        });
+        colorInput.addEventListener('input', (e) => {
+          if (/^#[0-9A-Fa-f]{6}$/.test(e.target.value)) {
+            colorPicker.value = e.target.value;
+          }
+        });
+      </script>
+
+      <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Create Zone</button>
+        <a href="/settings/zones/" class="btn btn-outline-secondary">Cancel</a>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/heim/frontend/templates/settings/zones.html
+++ b/heim/frontend/templates/settings/zones.html
@@ -1,0 +1,65 @@
+{% extends "settings/layout.html" %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h2>Zones</h2>
+  <a href="/settings/zones/new/" class="btn btn-primary">Add Zone</a>
+</div>
+
+<p class="text-body-secondary">Zones are logical locations that track measurements over time. Sensors can be assigned to zones, and reassigned when moved or replaced.</p>
+
+{% if zones %}
+<div class="table-responsive">
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th>Color</th>
+        <th>Name</th>
+        <th>Location</th>
+        <th>Type</th>
+        <th>Current Sensor</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for zone_id, name, location_name, is_outdoor, color, current_sensor_id in zones %}
+      <tr>
+        <td>
+          {% if color %}
+            <span style="display: inline-block; width: 20px; height: 20px; background-color: {{ color }}; border-radius: 3px; vertical-align: middle;"></span>
+          {% else %}
+            <span class="text-body-secondary">—</span>
+          {% endif %}
+        </td>
+        <td>
+          <a href="/settings/zones/{{ zone_id }}/">{{ name }}</a>
+        </td>
+        <td class="text-body-secondary">{{ location_name }}</td>
+        <td>
+          {% if is_outdoor %}
+            <span class="badge bg-primary">Outdoor</span>
+          {% else %}
+            <span class="badge bg-secondary">Indoor</span>
+          {% endif %}
+        </td>
+        <td>
+          {% if current_sensor_id %}
+            <span class="badge bg-success">Assigned</span>
+          {% else %}
+            <span class="badge bg-warning text-dark">No sensor</span>
+          {% endif %}
+        </td>
+        <td>
+          <a href="/settings/zones/{{ zone_id }}/" class="btn btn-sm btn-outline-secondary">Edit</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<div class="alert alert-info">
+  No zones configured yet. Click "Add Zone" to create one.
+</div>
+{% endif %}
+{% endblock %}

--- a/heim/sensors/cli.py
+++ b/heim/sensors/cli.py
@@ -7,7 +7,6 @@ from .queries import (
     add_exclusion,
     list_exclusions,
     remove_exclusion,
-    set_outdoor_sensor,
 )
 
 
@@ -23,7 +22,7 @@ async def list_sensors(*, account_id: int) -> None:
     """List all sensors for an account."""
     rows = await db.fetch(
         """
-        SELECT s.id, s.name, s.is_outdoor, l.name as location_name
+        SELECT s.id, s.name, l.name as location_name
         FROM sensor s
         JOIN location l ON l.id = s.location_id
         WHERE s.account_id = $1
@@ -35,32 +34,11 @@ async def list_sensors(*, account_id: int) -> None:
         click.echo("No sensors found.")
         return
 
-    click.echo(f"{'ID':>4}  {'Name':<30}  {'Location':<20}  Outdoor")
-    click.echo(f"{'--':>4}  {'----':<30}  {'--------':<20}  -------")
+    click.echo(f"{'ID':>4}  {'Name':<30}  Location")
+    click.echo(f"{'--':>4}  {'----':<30}  --------")
     for row in rows:
-        outdoor = "yes" if row["is_outdoor"] else ""
         name = row["name"] or "(unnamed)"
-        click.echo(f"{row['id']:>4}  {name:<30}  {row['location_name']:<20}  {outdoor}")
-
-
-@cli.command(name="set-outdoor")
-@click.option("--account-id", "-a", type=int, required=True, help="Account ID")
-@click.option("--sensor-id", "-s", type=int, required=True, help="Sensor ID")
-@click.option("--clear", is_flag=True, help="Clear the outdoor flag")
-@db.setup()
-async def set_outdoor(*, account_id: int, sensor_id: int, clear: bool) -> None:
-    """Mark a sensor as outdoor (or clear the flag with --clear)."""
-    updated = await set_outdoor_sensor(
-        account_id=account_id,
-        sensor_id=sensor_id,
-        is_outdoor=not clear,
-    )
-    if updated:
-        action = "cleared" if clear else "set"
-        click.echo(f"Outdoor flag {action} for sensor {sensor_id}")
-    else:
-        click.echo(f"Sensor {sensor_id} not found for account {account_id}", err=True)
-        raise SystemExit(1)
+        click.echo(f"{row['id']:>4}  {name:<30}  {row['location_name']}")
 
 
 @cli.command(name="exclude")

--- a/heim/zones/queries.py
+++ b/heim/zones/queries.py
@@ -1,0 +1,395 @@
+"""
+Zone queries for managing logical measurement locations.
+
+Zones represent places we want to track measurements over time (e.g., "Living Room").
+Sensors are assigned to zones for specific time periods via sensor_zone_assignment.
+"""
+
+from datetime import datetime, timedelta
+
+from .. import db
+from ..sensors.types import Attribute
+
+
+async def get_zones(
+    *, account_id: int, location_id: int, is_outdoor: bool | None = None
+) -> list[tuple[int, str, str | None]]:
+    """
+    Get zones for a location. Returns list of (id, name, color) tuples.
+
+    Args:
+        is_outdoor: If True, only outdoor zones. If False, only indoor.
+                    If None, all zones.
+    """
+    if is_outdoor is None:
+        query = """
+            SELECT z.id, z.name, z.color
+            FROM zone z
+            JOIN location l ON l.id = z.location_id
+            WHERE z.location_id = $1 AND l.account_id = $2
+            ORDER BY z.name
+        """
+        rows = await db.fetch(query, location_id, account_id)
+    else:
+        query = """
+            SELECT z.id, z.name, z.color
+            FROM zone z
+            JOIN location l ON l.id = z.location_id
+            WHERE z.location_id = $1 AND l.account_id = $2 AND z.is_outdoor = $3
+            ORDER BY z.name
+        """
+        rows = await db.fetch(query, location_id, account_id, is_outdoor)
+    return [(row["id"], row["name"], row["color"]) for row in rows]
+
+
+async def get_zone(
+    *, account_id: int, zone_id: int
+) -> tuple[int, str, int, str, bool, str | None] | None:
+    """
+    Get a single zone by ID.
+    Returns (id, name, location_id, location_name, is_outdoor, color) or None.
+    """
+    row = await db.fetchrow(
+        """
+        SELECT
+            z.id,
+            z.name,
+            z.location_id,
+            l.name as location_name,
+            z.is_outdoor,
+            z.color
+        FROM zone z
+        JOIN location l ON l.id = z.location_id
+        WHERE z.id = $1 AND l.account_id = $2
+        """,
+        zone_id,
+        account_id,
+    )
+    if not row:
+        return None
+    return (
+        row["id"],
+        row["name"],
+        row["location_id"],
+        row["location_name"],
+        row["is_outdoor"],
+        row["color"],
+    )
+
+
+async def get_all_zones(
+    *, account_id: int
+) -> list[tuple[int, str, str, bool, str | None, int | None]]:
+    """
+    Get all zones for an account with their details.
+
+    Returns list of (id, name, location_name, is_outdoor, color, current_sensor_id).
+    current_sensor_id is the currently assigned sensor (if any).
+    """
+    rows = await db.fetch(
+        """
+        SELECT
+            z.id,
+            z.name,
+            l.name as location_name,
+            z.is_outdoor,
+            z.color,
+            (
+                SELECT sza.sensor_id
+                FROM sensor_zone_assignment sza
+                WHERE sza.zone_id = z.id
+                  AND sza.active_range @> now()::timestamptz
+                LIMIT 1
+            ) as current_sensor_id
+        FROM zone z
+        JOIN location l ON l.id = z.location_id
+        WHERE l.account_id = $1
+        ORDER BY l.name, z.name
+        """,
+        account_id,
+    )
+    return [
+        (
+            row["id"],
+            row["name"],
+            row["location_name"],
+            row["is_outdoor"],
+            row["color"],
+            row["current_sensor_id"],
+        )
+        for row in rows
+    ]
+
+
+async def create_zone(
+    *,
+    account_id: int,
+    location_id: int,
+    name: str,
+    is_outdoor: bool = False,
+    color: str | None = None,
+) -> int | None:
+    """
+    Create a new zone.
+
+    Returns the zone ID or None if location doesn't belong to account.
+    """
+    zone_id: int | None = await db.fetchval(
+        """
+        INSERT INTO zone (location_id, name, is_outdoor, color)
+        SELECT $1, $2, $3, $4
+        FROM location
+        WHERE id = $1 AND account_id = $5
+        RETURNING id
+        """,
+        location_id,
+        name,
+        is_outdoor,
+        color,
+        account_id,
+    )
+    return zone_id
+
+
+async def update_zone(
+    *,
+    account_id: int,
+    zone_id: int,
+    name: str,
+    is_outdoor: bool,
+    color: str | None,
+) -> bool:
+    """Update zone name, is_outdoor flag, and color. Returns True if zone exists."""
+    result = await db.execute(
+        """
+        UPDATE zone z
+        SET name = $2, is_outdoor = $3, color = $4
+        FROM location l
+        WHERE z.id = $1 AND z.location_id = l.id AND l.account_id = $5
+        """,
+        zone_id,
+        name,
+        is_outdoor,
+        color or None,
+        account_id,
+    )
+    return result == "UPDATE 1"
+
+
+async def get_zone_measurements(
+    *, zone_id: int, attribute: Attribute, hours: int = 24
+) -> list[tuple[datetime, float]]:
+    """
+    Get measurements for a zone within the last N hours.
+    Returns list of (measured_at, value) tuples.
+    Automatically joins through sensor_zone_assignment to get data from all
+    sensors that were assigned to this zone during the time period.
+    Excludes measurements in any exclusion ranges.
+    """
+    since = datetime.now() - timedelta(hours=hours)
+    rows = await db.fetch(
+        """
+        SELECT m.measured_at, m.value
+        FROM sensor_measurement m
+        JOIN sensor_zone_assignment sza ON sza.sensor_id = m.sensor_id
+        WHERE sza.zone_id = $1
+          AND m.attribute = $2
+          AND m.measured_at > $3
+          AND sza.active_range @> m.measured_at
+          AND NOT EXISTS (
+              SELECT 1 FROM sensor_measurement_exclusion e
+              WHERE e.sensor_id = m.sensor_id
+                AND e.excluded @> m.measured_at
+          )
+        ORDER BY m.measured_at ASC
+        """,
+        zone_id,
+        attribute,
+        since,
+    )
+    return [(row["measured_at"], row["value"]) for row in rows]
+
+
+async def get_zone_measurements_averaged(
+    *,
+    zone_id: int,
+    attribute: Attribute,
+    hours: int = 24,
+    bucket_minutes: int = 60,
+) -> list[tuple[datetime, float]]:
+    """
+    Get measurements for a zone within the last N hours, averaged over time buckets.
+    Returns list of (bucket_start, avg_value) tuples.
+    Automatically joins through sensor_zone_assignment to get data from all
+    sensors that were assigned to this zone during the time period.
+    Excludes measurements in any exclusion ranges.
+
+    Args:
+        zone_id: The zone to fetch measurements for.
+        attribute: The measurement attribute (e.g., temperature).
+        hours: Number of hours to look back.
+        bucket_minutes: Size of time buckets in minutes for averaging.
+    """
+    since = datetime.now() - timedelta(hours=hours)
+    rows = await db.fetch(
+        """
+        SELECT
+            to_timestamp(
+                floor(extract(epoch from m.measured_at) / ($4 * 60)) * ($4 * 60)
+            ) AS bucket,
+            avg(m.value) AS avg_value
+        FROM sensor_measurement m
+        JOIN sensor_zone_assignment sza ON sza.sensor_id = m.sensor_id
+        WHERE sza.zone_id = $1
+          AND m.attribute = $2
+          AND m.measured_at > $3
+          AND sza.active_range @> m.measured_at
+          AND NOT EXISTS (
+              SELECT 1 FROM sensor_measurement_exclusion e
+              WHERE e.sensor_id = m.sensor_id
+                AND e.excluded @> m.measured_at
+          )
+        GROUP BY bucket
+        ORDER BY bucket ASC
+        """,
+        zone_id,
+        attribute,
+        since,
+        bucket_minutes,
+    )
+    return [(row["bucket"], float(row["avg_value"])) for row in rows]
+
+
+async def assign_sensor_to_zone(
+    *, account_id: int, zone_id: int, sensor_id: int
+) -> bool:
+    """
+    Assign a sensor to a zone, starting from now.
+
+    If the sensor is currently assigned to another zone, ends that assignment first.
+    Returns True if successful, False if zone or sensor doesn't exist.
+    """
+    # Verify zone and sensor belong to account
+    check = await db.fetchrow(
+        """
+        SELECT
+            EXISTS(
+                SELECT 1 FROM zone z JOIN location l ON l.id = z.location_id
+                WHERE z.id = $1 AND l.account_id = $3
+            ) as zone_exists,
+            EXISTS(
+                SELECT 1 FROM sensor WHERE id = $2 AND account_id = $3
+            ) as sensor_exists
+        """,
+        zone_id,
+        sensor_id,
+        account_id,
+    )
+    if not check or not check["zone_exists"] or not check["sensor_exists"]:
+        return False
+
+    # End any current assignment for this sensor
+    await db.execute(
+        """
+        UPDATE sensor_zone_assignment
+        SET active_range = tstzrange(lower(active_range), now(), '[)')
+        WHERE sensor_id = $1 AND upper(active_range) IS NULL
+        """,
+        sensor_id,
+    )
+
+    # Create new assignment
+    await db.execute(
+        """
+        INSERT INTO sensor_zone_assignment (zone_id, sensor_id, active_range)
+        VALUES ($1, $2, tstzrange(now(), null, '[)'))
+        """,
+        zone_id,
+        sensor_id,
+    )
+    return True
+
+
+async def unassign_sensor(*, account_id: int, sensor_id: int) -> bool:
+    """
+    End the current zone assignment for a sensor (if any).
+    Returns True if an assignment was ended.
+    """
+    result = await db.execute(
+        """
+        UPDATE sensor_zone_assignment sza
+        SET active_range = tstzrange(lower(active_range), now(), '[)')
+        FROM sensor s
+        WHERE sza.sensor_id = $1
+          AND sza.sensor_id = s.id
+          AND s.account_id = $2
+          AND upper(sza.active_range) IS NULL
+        """,
+        sensor_id,
+        account_id,
+    )
+    return result == "UPDATE 1"
+
+
+async def get_zone_assignments(
+    *, account_id: int, zone_id: int
+) -> list[tuple[int, int, str | None, datetime, datetime | None]]:
+    """
+    Get assignment history for a zone.
+    Returns list of (assignment_id, sensor_id, sensor_name, start, end) tuples.
+    End is None for currently active assignments.
+    """
+    rows = await db.fetch(
+        """
+        SELECT
+            sza.id,
+            sza.sensor_id,
+            s.name as sensor_name,
+            lower(sza.active_range) as start_time,
+            upper(sza.active_range) as end_time
+        FROM sensor_zone_assignment sza
+        JOIN sensor s ON s.id = sza.sensor_id
+        JOIN zone z ON z.id = sza.zone_id
+        JOIN location l ON l.id = z.location_id
+        WHERE sza.zone_id = $1 AND l.account_id = $2
+        ORDER BY lower(sza.active_range) DESC
+        """,
+        zone_id,
+        account_id,
+    )
+    return [
+        (
+            row["id"],
+            row["sensor_id"],
+            row["sensor_name"],
+            row["start_time"],
+            row["end_time"],
+        )
+        for row in rows
+    ]
+
+
+async def get_sensor_current_zone(
+    *, account_id: int, sensor_id: int
+) -> tuple[int, str] | None:
+    """
+    Get the current zone a sensor is assigned to.
+    Returns (zone_id, zone_name) or None if not assigned.
+    """
+    row = await db.fetchrow(
+        """
+        SELECT z.id, z.name
+        FROM sensor_zone_assignment sza
+        JOIN zone z ON z.id = sza.zone_id
+        JOIN location l ON l.id = z.location_id
+        JOIN sensor s ON s.id = sza.sensor_id
+        WHERE sza.sensor_id = $1
+          AND s.account_id = $2
+          AND sza.active_range @> now()::timestamptz
+        """,
+        sensor_id,
+        account_id,
+    )
+    if not row:
+        return None
+    return (row["id"], row["name"])


### PR DESCRIPTION
## Summary

This PR introduces a new "zones" concept to separate physical sensor devices from logical measurement locations. Zones represent places we want to track measurements over time (e.g., "Living Room"), while sensors are physical devices that can be assigned to zones for specific time periods. This allows moving sensors between zones and replacing sensors while maintaining continuous historical data for a zone.

## Key Changes

- **New zones module** (`heim/zones/queries.py`): Complete zone management with 13 query functions for CRUD operations, sensor assignments, and measurement retrieval
  - `get_zones()`, `get_zone()`, `get_all_zones()` - zone queries
  - `create_zone()`, `update_zone()` - zone management
  - `assign_sensor_to_zone()`, `unassign_sensor()`, `get_zone_assignments()` - sensor assignment lifecycle
  - `get_zone_measurements()`, `get_zone_measurements_averaged()` - measurement queries through zone assignments
  - `get_sensor_current_zone()` - reverse lookup for sensor's current zone

- **Database schema** (`heim/db/migrations/0017_add_zones.sql`): 
  - New `zone` table with location, name, is_outdoor flag, and color
  - New `sensor_zone_assignment` table with time-range based assignments using PostgreSQL `tstzrange`
  - GiST exclusion constraint prevents sensor overlap across zones
  - Data migration: creates zones from existing sensors and establishes initial assignments

- **Sensor model refactoring** (`heim/sensors/queries.py`):
  - Removed `is_outdoor` and `color` properties from sensors (moved to zones)
  - Removed `get_sensors()` and `set_outdoor_sensor()` functions (replaced by zone equivalents)
  - Updated `get_all_sensors()` and `get_sensor()` to return only device-relevant data (id, name, location, source)

- **Frontend settings** (`heim/frontend/settings.py`):
  - New zone management endpoints: list, create, detail, update, assign/unassign sensors
  - Updated sensor detail view to show current zone assignment instead of outdoor/color properties
  - Simplified sensor update to only handle name changes

- **Frontend templates**:
  - New `zones.html`: zone listing with current sensor assignments
  - New `zone_form.html`: zone creation form
  - New `zone_detail.html`: zone editing with sensor assignment management and assignment history
  - Updated `sensor_detail.html`: removed outdoor/color fields, added current zone display
  - Updated `sensors.html`: simplified table, removed outdoor/color columns

- **Main views** (`heim/frontend/views.py`):
  - Refactored location overview to use zones instead of sensors for temperature charts
  - Updated chart data retrieval to use `get_zone_measurements_averaged()` instead of sensor-based queries

- **CLI** (`heim/sensors/cli.py`):
  - Removed `set-outdoor` command (outdoor flag now managed via zones)
  - Updated `list-sensors` output to remove outdoor column

## Implementation Details

- **Time-range based assignments**: Uses PostgreSQL `tstzrange` with GiST indexing for efficient temporal queries and constraint enforcement
- **Backward compatibility**: Migration script automatically creates zones from existing sensors, preserving all historical data
- **Measurement continuity**: Zone measurements automatically aggregate from all sensors assigned during the query period
- **Exclusion support**: Zone measurement queries respect existing sensor measurement exclusions

https://claude.ai/code/session_01MBUmpb6hHtzL8MKYV3hHLv